### PR TITLE
Adding Liveness, Readiness, and Startup Probe configurability 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 > [!NOTE]  
+
 > This is a community-maintained repository and is not actively maintained by the Directus Core Team.
 
 # Directus Community Helm Charts

--- a/charts/directus/Chart.yaml
+++ b/charts/directus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -68,14 +68,18 @@ spec:
             - name: http
               containerPort: 8055
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml (omit .Values.livenessProbe "enabled") | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml (omit .Values.readinessProbe "enabled") | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            {{- toYaml (omit .Values.startupProbe "enabled") | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -85,21 +85,16 @@ livenessProbe:
   httpGet:
     path: /
     port: http
-  failureThreshold: 5
-  periodSeconds: 10
 readinessProbe:
   enabled: true
   httpGet:
     path: /
     port: http
-  failureThreshold: 5
-  periodSeconds: 10
 startupProbe:
+  enabled: false
   httpGet:
     path: /
     port: http
-  failureThreshold: 30
-  periodSeconds: 10
 
 
 nodeSelector: {}

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -80,6 +80,28 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 5
+  periodSeconds: 10
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 5
+  periodSeconds: 10
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 30
+  periodSeconds: 10
+
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Additional configuration for startup, readiness, and liveness probes. Comes in handy on less powerful hardware, where startup times can cause the deployment to fail.