### PR TITLE
Attach Kubernetes Secrets to the Directus pod

### DIFF
--- a/charts/directus/Chart.yaml
+++ b/charts/directus/Chart.yaml
@@ -19,8 +19,8 @@ maintainers:
     email: sindieiev@protonmail.ch
     url: https://github.com/directus-labs/helm-chart
 
-version: 1.0.3
-appVersion: "11.1.1"
+version: 1.0.4
+appVersion: "11.1.2"
 
 dependencies:
 - name: mariadb

--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
+            {{- range $val := .Values.attachExistingSecrets }}
+            - secretRef:
+                name: {{ $val }}
+            {{- end }}
             - configMapRef:
                 name: {{ include "directus.fullname" . }}-configmap
           env:

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -72,6 +72,8 @@ ingress:
 
 extraEnvVars: []
 
+attachExistingSecrets: []
+  # - existingSecretInKubernetes
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -118,6 +120,7 @@ affinity: {}
 extraVolumes: []
 
 extraVolumeMounts: []
+
 
 mariadb:
   # The switch to switch off the installation of the mariadb, the rest of the settings are being used during the installation

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: directus/directus 
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "11.1.1"
+  tag: "11.1.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Adding a possibility to attach existing secrets to Directus pod. That could be useful for calling sensitive environment variables in directus flow, eg API keys