### PR TITLE
change the approach on how PUBLIC_URL is fulfilled

### DIFF
--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
                   key: KEY
             {{- if .Values.ingress.enabled }}
             - name: PUBLIC_URL
-              value: http{{ if .Values.ingress.tls }}s{{ end }}://{{(index .Values.ingress.hosts 0).host }}
+              value: http{{ if .Values.ingress.enableTLS }}s{{ end }}://{{(index .Values.ingress.hosts 0).host }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- tpl (toYaml .Values.extraEnvVars) $ | nindent 12 }}

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -56,6 +56,7 @@ service:
 
 ingress:
   enabled: false
+  enableTLS: true
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Previously `PUBLIC_URL` environment variable was set to `http` or `https` basing on `tls` list in `values.yaml`

This approach does not work if Directus is exposed with AWS ALB controller. Because AWS ALB does not use `tls` list to inject certificate, it uses ingress annotations. 

Reworked the way how `PUBLIC_URL` environment variable is fulfilled 