### PR TITLE
feature: add sidecars and init containers options on deployment

### DIFF
--- a/charts/directus/templates/_helpers.tpl
+++ b/charts/directus/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "directus.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "directus.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "directus.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       serviceAccountName: {{ include "directus.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- include "directus.render" ( dict "value" .Values.initContainers "context" $ ) | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -95,6 +99,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+        {{- if .Values.sidecars }}
+        {{- include "directus.render" ( dict "value" .Values.sidecars "context" $ ) | nindent 8 }}
+        {{- end }}
         {{- if .Values.sidecar.enabled }}
         - name: {{ .Chart.Name }}-sidecar
           image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -19,6 +19,12 @@ nameOverride: ""
 # -- Completely overrides Chart name
 fullnameOverride: ""
 
+# -- Init Containers for Directus pod
+initContainers: []
+
+# -- Sidecars for Directus pod
+sidecars: []
+
 sidecar:
   # -- Sidecars for Directus pod
   enabled: false

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -21,9 +21,26 @@ fullnameOverride: ""
 
 # -- Init Containers for Directus pod
 initContainers: []
+#  - name: myinitcontainer
+#    image: alpine:latest
+#    restartPolicy: Always
+#    command:
+#      - sh
+#      - -c
+#      - cat /opt/file.txt
+#    volumeMounts:
+#      - name: opt
+#        mountPath: /opt
 
 # -- Sidecars for Directus pod
 sidecars: []
+#  - name: busybox
+#    image: busybox:latest
+#    imagePullPolicy: Always
+#    command:
+#      - /bin/sh
+#      - -c
+#      - sleep 3600;
 
 sidecar:
   # -- Sidecars for Directus pod


### PR DESCRIPTION
This pull request enables the possibility to add multiple init containers or sidecar containers.
Init container can be useful for example if we want to create a volume and pull data from a github repository on pod startup.
We could also use a sidecar container like git-sync but right now we're limited with only one sidecar container per deployment.