### PR TITLE
Support custom DB_PORT values based on Helm chart configuration

### DIFF
--- a/charts/directus/README.md
+++ b/charts/directus/README.md
@@ -65,6 +65,7 @@ Directus is a real-time API and App dashboard for managing SQL database content.
 | mysql.auth.username | string | `"directus_mysql"` |  |
 | mysql.enableInstallation | bool | `true` | The switch to switch off the installation of the mysql The rest of the settings are being used during the installation and for DB connection Link to the values.yaml file in bitnami repo - https://github.com/bitnami/charts/blob/main/bitnami/mysql/values.yaml |
 | mysql.mysqlURL | string | `""` |  |
+| mysql.mysqlPort | string | `""` |  |
 | nameOverride | string | `""` | Helm name override in Chart.yaml. This name is being used for resource naming |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
@@ -74,6 +75,7 @@ Directus is a real-time API and App dashboard for managing SQL database content.
 | postgresql.auth.username | string | `"directus_postgres"` |  |
 | postgresql.enableInstallation | bool | `false` | The switch to switch off the installation of the postgresql The rest of the settings are being used during the installation and for DB connection Link to the values.yaml file in bitnami repo - https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml |
 | postgresql.postgresqlURL | string | `""` |  |
+| postgresql.postgresqlPort | string | `""` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |

--- a/charts/directus/templates/configmap.yaml
+++ b/charts/directus/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   DB_CLIENT: {{ .Values.databaseEngine }}
   DB_HOST: {{- if eq .Values.databaseEngine "mysql" }} {{- if .Values.mysql.mysqlURL }} "{{ .Values.mysql.mysqlURL }}" {{- else }} "{{ .Release.Name }}-mysql.{{ .Release.Namespace }}.svc.cluster.local" {{- end }} {{- else if eq .Values.databaseEngine "postgresql" }} {{- if .Values.postgresql.postgresqlURL }} "{{ .Values.postgresql.postgresqlURL }}" {{- else }} "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local" {{- end }} {{- end }}
-  DB_PORT: {{- if eq .Values.databaseEngine "mysql" }} "3306" {{- else if eq .Values.databaseEngine "postgresql" }} "5432" {{- else }} "" {{- end }}
+  DB_PORT: {{ if eq .Values.databaseEngine "mysql" }}{{ default "3306" .Values.mysql.mysqlPort }}{{ else if eq .Values.databaseEngine "postgresql" }}{{ default "5432" .Values.postgresql.postgresqlPort }}{{ end }}
   DB_DATABASE: {{- if eq .Values.databaseEngine "mysql" }} {{ .Values.mysql.auth.database }} {{- else if eq .Values.databaseEngine "postgresql" }} {{ .Values.postgresql.auth.database }} {{- else }} "" {{- end }}
   DB_USER: {{- if eq .Values.databaseEngine "mysql" }} {{ .Values.mysql.auth.username }} {{- else if eq .Values.databaseEngine "postgresql" }} {{ .Values.postgresql.auth.username }} {{- else }} "" {{- end }}
   ADMIN_EMAIL: "{{ .Values.adminEmail }}"

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -193,6 +193,7 @@ mysql:
   # Please note mysql.auth.database will be used as a name of the database
   # and mysql.auth.username will be used as username during the connection
   mysqlURL: ""
+  mysqlPort: ""
 
 postgresql:
   # -- The switch to switch off the installation of the postgresql
@@ -208,6 +209,7 @@ postgresql:
   # Please note postgresql.auth.database will be used as a name of the database
   # and postgresql.auth.username will be used as username during the connection
   postgresqlURL: ""
+  postgresqlPort: ""
 
 redis:
   # -- Switch to enable Redis


### PR DESCRIPTION
This pull request updates the Directus Helm chart to set the DB_PORT environment variable dynamically based on the selected database engine (mysql or postgresql). The logic falls back to default ports (3306 for MySQL, 5432 for PostgreSQL) when no explicit port is defined in values.yaml.

This is needed in environments where the database is not using the default port such as managed services, port-forwarded instances, or non-standard deployments.

Changes included:
- Conditional Helm templating to set DB_PORT from .Values.mysql.mysqlPort or .Values.postgresql.postgresqlPort.
- Uses defaults if the port is left empty or unset.
- Update the documentation