### PR TITLE
Fix misconfiguration of DB_PORT by quoting value as string

### DIFF
--- a/charts/directus/templates/configmap.yaml
+++ b/charts/directus/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   DB_CLIENT: {{ .Values.databaseEngine }}
   DB_HOST: {{- if eq .Values.databaseEngine "mysql" }} {{- if .Values.mysql.mysqlURL }} "{{ .Values.mysql.mysqlURL }}" {{- else }} "{{ .Release.Name }}-mysql.{{ .Release.Namespace }}.svc.cluster.local" {{- end }} {{- else if eq .Values.databaseEngine "postgresql" }} {{- if .Values.postgresql.postgresqlURL }} "{{ .Values.postgresql.postgresqlURL }}" {{- else }} "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local" {{- end }} {{- end }}
-  DB_PORT: {{ if eq .Values.databaseEngine "mysql" }}{{ default "3306" .Values.mysql.mysqlPort }}{{ else if eq .Values.databaseEngine "postgresql" }}{{ default "5432" .Values.postgresql.postgresqlPort }}{{ end }}
+  DB_PORT: {{ if eq .Values.databaseEngine "mysql" }}{{ default "3306" .Values.mysql.mysqlPort | quote }}{{ else if eq .Values.databaseEngine "postgresql" }}{{ default "5432" .Values.postgresql.postgresqlPort | quote }}{{ end }}
   DB_DATABASE: {{- if eq .Values.databaseEngine "mysql" }} {{ .Values.mysql.auth.database }} {{- else if eq .Values.databaseEngine "postgresql" }} {{ .Values.postgresql.auth.database }} {{- else }} "" {{- end }}
   DB_USER: {{- if eq .Values.databaseEngine "mysql" }} {{ .Values.mysql.auth.username }} {{- else if eq .Values.databaseEngine "postgresql" }} {{ .Values.postgresql.auth.username }} {{- else }} "" {{- end }}
   ADMIN_EMAIL: "{{ .Values.adminEmail }}"

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -183,7 +183,7 @@ mysql:
   # -- The switch to switch off the installation of the mysql
   # The rest of the settings are being used during the installation and for DB connection
   # Link to the values.yaml file in bitnami repo - https://github.com/bitnami/charts/blob/main/bitnami/mysql/values.yaml
-  enableInstallation: false
+  enableInstallation: true
   auth:
     existingSecret: "directus-mysql-secret"
     database: "directus_mysql"
@@ -192,8 +192,8 @@ mysql:
   # Otherwise leave it empty to use mysql that being installed in the cluster with this chart
   # Please note mysql.auth.database will be used as a name of the database
   # and mysql.auth.username will be used as username during the connection
-  mysqlURL: "db-service"
-  mysqlPort: "3456"
+  mysqlURL: ""
+  mysqlPort: ""
 
 postgresql:
   # -- The switch to switch off the installation of the postgresql

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -183,7 +183,7 @@ mysql:
   # -- The switch to switch off the installation of the mysql
   # The rest of the settings are being used during the installation and for DB connection
   # Link to the values.yaml file in bitnami repo - https://github.com/bitnami/charts/blob/main/bitnami/mysql/values.yaml
-  enableInstallation: true
+  enableInstallation: false
   auth:
     existingSecret: "directus-mysql-secret"
     database: "directus_mysql"
@@ -192,8 +192,8 @@ mysql:
   # Otherwise leave it empty to use mysql that being installed in the cluster with this chart
   # Please note mysql.auth.database will be used as a name of the database
   # and mysql.auth.username will be used as username during the connection
-  mysqlURL: ""
-  mysqlPort: ""
+  mysqlURL: "db-service"
+  mysqlPort: "3456"
 
 postgresql:
   # -- The switch to switch off the installation of the postgresql


### PR DESCRIPTION
Hi,

This is a fix for https://github.com/directus-labs/helm-chart/pull/67, which caused the deployment to fail due to a misconfiguration of DB_PORT being set as an integer instead of a string.

I’ve now properly tested it locally, and everything works as expected 

Default installation  :  

![CleanShot 2025-06-03 at 22 49 42@2x](https://github.com/user-attachments/assets/1c03110e-0321-4b17-96f9-ee6b83d2b162)

Custom port and url  :
![Code 2025-06-03 22 40 28](https://github.com/user-attachments/assets/72c4a824-f991-41af-9410-8eff53fecbf4)


Apologies for that.