### PR TITLE
Updated HPA

### DIFF
--- a/charts/directus/templates/hpa.yaml
+++ b/charts/directus/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if and (hasKey .Values.autoscaling "targetMemoryUtilizationPercentage") (not (kindIs "invalid" (get .Values.autoscaling "targetMemoryUtilizationPercentage"))) }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ get .Values.autoscaling "targetMemoryUtilizationPercentage" }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
* The current v2 no longer supports targetAverageUtilization, updating to target/type
* As the Memory target is commented by default it is better to check for the keys existence as opposed to just including it. (haskey)