### PR TITLE
Add configurable Directus service annotations

### DIFF
--- a/charts/directus/templates/service.yaml
+++ b/charts/directus/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "directus.fullname" . }}
   labels:
     {{- include "directus.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -95,6 +95,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  # -- Service annotations. Usually used in cloud environments
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
This allows for service annotations, which (in my case) allows me to configure Directus under GCP's L7 Load Balancer.