### PR TITLE
Only set replicas if deployment.replicaCount is defined and autoscaling is disabled

### DIFF
--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "directus.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicaCount) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:


### PR DESCRIPTION
In my case I'm using KEDA, which creates HPA resources for me. As a result I'd like to have `replicas` left out unless `replicaCount` is set in `values.yaml`, which prevents continual diffs in controllers like ArgoCD.

Technically behaviour changes here, in that `replicas` will now be omitted from the applied object unless `replicaCount` is explicitly set. However, out of the box `replicas` will be set to 1 anyway, so there'll be no functional change.